### PR TITLE
docs: Update GitHub org URLs from bowen31337 to clawinfra

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All contributions tracked in [CONTRIBUTORS.md](./CONTRIBUTORS.md)
 
 ## 🔗 Links
 
-- **GitHub:** https://github.com/bowen31337/claw-chain
+- **GitHub:** https://github.com/clawinfra/claw-chain
 - **Community:** [Moltbook](https://moltbook.com) (announcement coming)
 - **Contact:** Open an issue or join discussions
 


### PR DESCRIPTION
Repository has been transferred to the `clawinfra` organization for better community ownership.

This PR updates all documentation references from the personal account to the org.

**Changes:**
- README.md links updated
- All markdown files scanned for old URLs

Ready to merge.