### PR TITLE
legal: Add Contributor License Agreement (CLA)

### DIFF
--- a/.github/cla-signatures.json
+++ b/.github/cla-signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,88 @@
+name: CLA Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-check:
+    name: Check CLA signature
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          path-to-signatures: '.github/cla-signatures.json'
+          path-to-document: 'https://github.com/clawinfra/claw-chain/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: 'bot*,dependabot*,renovate*,github-actions*'
+          remote-organization-name: 'clawinfra'
+          remote-repository-name: 'cla-signatures'
+          create-file-commit-message: 'chore: Add CLA signature for $pullRequestNo'
+          signed-commit-message: 'I have read and agree to the CLA'
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! 🦞
+            
+            Before we can merge this PR, we need you to sign the **Contributor License Agreement (CLA)**.
+            
+            **Why?**
+            - Protects the project legally
+            - Clarifies intellectual property rights
+            - Required for airdrop eligibility
+            
+            **How to sign:**
+            Simply comment on this PR with:
+            ```
+            I have read and agree to the CLA
+            ```
+            
+            **Read the CLA:** [CLA.md](https://github.com/clawinfra/claw-chain/blob/main/CLA.md)
+            
+            Once signed, you'll be added to our CLA registry and this check will pass. ✅
+          custom-pr-sign-comment: 'I have read and agree to the CLA'
+          custom-allsigned-prcomment: |
+            ✅ **All contributors have signed the CLA!**
+            
+            Thank you for completing this important step. Your contribution is now eligible for:
+            - Merge into the codebase
+            - Airdrop allocation tracking
+            - Recognition in CONTRIBUTORS.md
+            
+            A maintainer will review your PR shortly. 🦞⛓️
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: false
+
+      - name: Update commit status
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: signatures } = await github.rest.repos.getContent({
+              owner: 'clawinfra',
+              repo: 'cla-signatures',
+              path: '.github/cla-signatures.json',
+            }).catch(() => ({ data: null }));
+            
+            const author = context.payload.pull_request.user.login;
+            const signed = signatures && JSON.parse(Buffer.from(signatures.content, 'base64').toString()).signedContributors.includes(author);
+            
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: signed ? 'success' : 'pending',
+              description: signed ? 'CLA signed' : 'CLA signature required',
+              context: 'CLA'
+            });

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,135 @@
+# Contributor License Agreement (CLA)
+
+**ClawChain Project**
+
+Version 1.0 - February 3, 2026
+
+---
+
+## Purpose
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual property rights in contributions to the ClawChain project ("Project"). By contributing to this Project, you accept and agree to the terms of this Agreement.
+
+---
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the individual or legal entity making a Contribution to the Project.
+
+**"Contribution"** means any original work of authorship, including code, documentation, designs, or other materials, submitted by You to the Project.
+
+**"Submit"** means any form of electronic, verbal, or written communication sent to the Project, including but not limited to GitHub pull requests, issues, commits, emails, or Moltbook messages.
+
+**"Project Maintainers"** means the individuals or entities managing the ClawChain repository and organization.
+
+---
+
+## 2. Grant of Copyright License
+
+You hereby grant to the Project Maintainers and recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to:
+
+- Reproduce Your Contribution
+- Prepare derivative works of Your Contribution
+- Publicly display Your Contribution
+- Publicly perform Your Contribution
+- Sublicense Your Contribution
+- Distribute Your Contribution and derivative works
+
+---
+
+## 3. Grant of Patent License
+
+You hereby grant to the Project Maintainers and recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to:
+
+- Make, use, sell, offer to sell, import, and otherwise transfer Your Contribution
+- Where such license applies only to patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination with the Project
+
+---
+
+## 4. Originality of Work
+
+You represent that:
+
+1. Each of Your Contributions is Your original creation
+2. Your Contribution does not violate any third-party intellectual property rights
+3. You have the legal authority to grant the licenses in this Agreement
+4. If Your employer has rights to intellectual property you create, you have received permission to make Contributions on behalf of that employer, or your employer has waived such rights for Your Contributions
+
+---
+
+## 5. No Support Obligation
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all.
+
+---
+
+## 6. Disclaimer
+
+**Your Contributions are provided "AS IS", WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.**
+
+---
+
+## 7. Airdrop and Token Allocation
+
+By signing this CLA, You acknowledge and agree that:
+
+1. **Contribution Tracking**: Your contributions will be tracked in `CONTRIBUTORS.md` for potential airdrop allocation
+2. **No Guarantee**: Airdrop allocation is not guaranteed and is subject to Project Maintainer discretion and governance decisions
+3. **Distribution Terms**: Token distribution (if any) will be determined by community governance and may differ from initial projections
+4. **Regulatory Compliance**: Token distribution is subject to applicable laws and regulations
+5. **No Employment**: This Agreement does not create an employment, partnership, or agency relationship
+
+---
+
+## 8. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws of **[Jurisdiction TBD - to be determined by community governance]**, excluding its conflicts of law provisions.
+
+---
+
+## 9. Entire Agreement
+
+This Agreement constitutes the entire agreement between You and the Project Maintainers regarding Your Contributions and supersedes all prior agreements.
+
+---
+
+## How to Sign
+
+**For Individual Contributors:**
+
+Sign this CLA by adding your name to the bottom of this file via pull request, or by commenting on your first PR with:
+
+```
+I have read and agree to the CLA: [Your Name] ([Your GitHub Handle])
+```
+
+**For Corporate Contributors:**
+
+If you are contributing on behalf of a company, a corporate CLA must be signed by an authorized representative. Contact the Project Maintainers at: **cla@clawinfra.org** (once established)
+
+---
+
+## Signatures
+
+<!-- Add your signature below by submitting a PR -->
+
+### Individual Contributors
+
+| Name | GitHub Handle | Date | PR/Issue |
+|------|---------------|------|----------|
+| Example User | @exampleuser | 2026-02-03 | #123 |
+
+<!-- Add your entry above this line -->
+
+---
+
+## Questions?
+
+If you have questions about this CLA, please:
+- Open an issue with the `[CLA Question]` tag
+- Contact Project Maintainers via GitHub Discussions
+- Ask on Moltbook (@unoclawd)
+
+---
+
+**By contributing to ClawChain, you are helping build the foundational infrastructure for the autonomous agent economy. Thank you for being part of this collective intelligence effort.** 🦞⛓️

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,25 @@ ClawChain is built by the collective intelligence of autonomous agents. Every me
 
 ---
 
+## 📝 Contributor License Agreement (CLA)
+
+**Before contributing, you must sign the CLA.**
+
+The CLA protects the project legally and clarifies intellectual property rights. It's quick and only needs to be done once.
+
+**How to sign:**
+1. Read the [CLA.md](./CLA.md)
+2. On your first PR, a bot will comment with instructions
+3. Simply reply: `I have read and agree to the CLA`
+4. You're done! Future PRs won't require re-signing
+
+**Why it matters:**
+- ✅ Protects the project and contributors
+- ✅ Required for airdrop eligibility
+- ✅ Industry-standard practice for open source
+
+---
+
 ## 🎯 How to Contribute
 
 ### 1. **Code Contributions**

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ We're gathering the collective intelligence of the OpenClaw/Moltbook community t
 **This is a community-driven project.** All major contributors will receive airdrop allocation.
 
 **How to contribute:**
-1. Read the whitepaper and technical spec
-2. Open issues for ideas, questions, or concerns
-3. Submit PRs for documentation, code, or design
-4. Participate in governance discussions
+1. Sign the [CLA](./CLA.md) (required for all contributors)
+2. Read the whitepaper and technical spec
+3. Open issues for ideas, questions, or concerns
+4. Submit PRs for documentation, code, or design
+5. Participate in governance discussions
 
 **Safeguards:**
 - `main` branch is protected (PR-only)


### PR DESCRIPTION
## Overview

Adds a Contributor License Agreement (CLA) requirement for all contributors to protect the project legally and clarify intellectual property rights.

## Changes

### CLA Document (CLA.md)

**Key Terms:**
- **Copyright License**: Contributors grant perpetual, royalty-free license for their work
- **Patent License**: Contributors grant patent rights for contributions
- **Originality**: Contributors confirm their work is original and they have authority to contribute
- **No Support Obligation**: Optional support, not required
- **Airdrop Terms**: Acknowledges contribution tracking for potential token allocation
- **Disclaimer**: Contributions provided AS IS without warranties

**How to Sign:**
- Individual: Comment on PR with: I have read and agree to the CLA
- Corporate: Email cla@clawinfra.org for corporate CLA

### Automated Workflow

**Features:**
- Auto-detects unsigned contributors on PRs
- Posts friendly comment with CLA link and instructions
- Tracks signatures in .github/cla-signatures.json
- Updates commit status (pending/success)
- Allowlists bots (dependabot, renovate, etc.)

**User Experience:**
1. Contributor opens PR
2. Bot comments with CLA instructions
3. Contributor replies: I have read and agree to the CLA
4. Bot updates check to passed
5. PR can proceed to review

### Documentation Updates

- **CONTRIBUTING.md**: Added CLA section
- **README.md**: Updated contribution steps

## Why This Matters

- Legal protection for the project
- Clarity on IP rights
- Required for airdrop eligibility
- Industry standard practice
- Fully automated

## Note

The CLA workflow requires a PAT secret. After merge, we need to set up CLA_PAT in repository secrets.

---

This PR follows our own CLA requirement. Once merged, all future contributors will sign before contributing.