### PR TITLE
feat: implement pallet-agent-did (ADR-003)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,10 @@ members = [
     "node",
     "runtime",
     "pallets/agent-registry",
+    "pallets/agent-did",
     "pallets/claw-token",
     "pallets/reputation",
     "pallets/task-market",
-    "pallets/gas-quota",
-    "pallets/rpc-registry",
 ]
 resolver = "2"
 
@@ -95,11 +94,12 @@ substrate-wasm-builder = { version = "31.1" }
 
 # ClawChain pallets
 pallet-agent-registry = { path = "pallets/agent-registry", default-features = false }
+pallet-agent-did = { path = "pallets/agent-did", default-features = false }
 pallet-claw-token = { path = "pallets/claw-token", default-features = false }
 pallet-reputation = { path = "pallets/reputation", default-features = false }
 pallet-task-market = { path = "pallets/task-market", default-features = false }
-pallet-rpc-registry = { path = "pallets/rpc-registry", default-features = false }
 pallet-gas-quota = { path = "pallets/gas-quota", default-features = false }
+pallet-rpc-registry = { path = "pallets/rpc-registry", default-features = false }
 
 # Serde
 serde = { version = "1.0", features = ["derive"] }

--- a/pallets/agent-did/Cargo.toml
+++ b/pallets/agent-did/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "pallet-agent-did"
+version = "0.1.0"
+description = "ClawChain Agent DID Pallet - W3C Decentralized Identifier system for on-chain agent identity"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+codec = { workspace = true }
+scale-info = { workspace = true }
+log = { workspace = true }
+
+# FRAME
+frame-benchmarking = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+
+# Substrate primitives
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true, default-features = true }
+sp-io = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "scale-info/std",
+    "log/std",
+    "frame-benchmarking?/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+]
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+]

--- a/pallets/agent-did/src/lib.rs
+++ b/pallets/agent-did/src/lib.rs
@@ -1,0 +1,392 @@
+//! # Agent DID Pallet
+//!
+//! On-chain W3C DID document management for ClawChain agents.
+//!
+//! ## Overview
+//!
+//! This pallet implements the `did:claw` DID method for agent identity:
+//! - DID format: `did:claw:{AccountId}`
+//! - Storage: DID documents, service endpoints, verification methods
+//! - Lifecycle: register → update → deactivate
+//!
+//! ## Interface
+//!
+//! ### Dispatchable Functions
+//!
+//! - `register_did` — Create a new DID document for the caller
+//! - `update_did` — Update the DID document controller or metadata
+//! - `deactivate_did` — Permanently deactivate a DID document
+//! - `add_service_endpoint` — Add a service endpoint to a DID document
+//! - `remove_service_endpoint` — Remove a service endpoint
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod tests;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    // ========== Types ==========
+
+    /// Sequential ID for service endpoints within a DID document.
+    pub type ServiceEndpointId = u32;
+
+    // ========== Data Structures ==========
+
+    /// Status of a DID document.
+    #[derive(
+        Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen,
+        codec::DecodeWithMemTracking,
+    )]
+    pub enum DidStatus {
+        /// DID document is active.
+        Active,
+        /// DID document has been permanently deactivated.
+        Deactivated,
+    }
+
+    impl Default for DidStatus {
+        fn default() -> Self {
+            DidStatus::Active
+        }
+    }
+
+    /// A W3C DID document stored on-chain.
+    ///
+    /// Represents `did:claw:{AccountId}` where the AccountId is the map key.
+    #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+    #[scale_info(skip_type_params(T))]
+    pub struct DidDocument<T: Config> {
+        /// The account that controls this DID document.
+        pub controller: T::AccountId,
+        /// Optional JSON-LD context or metadata (e.g. linked service roots).
+        pub metadata: BoundedVec<u8, T::MaxMetadataLength>,
+        /// DID document status.
+        pub status: DidStatus,
+        /// Block number when the DID was registered.
+        pub registered_at: BlockNumberFor<T>,
+        /// Block number of the last update.
+        pub updated_at: BlockNumberFor<T>,
+        /// Monotonic counter for service endpoint IDs.
+        pub next_service_id: ServiceEndpointId,
+    }
+
+    // Manual impl required: DecodeWithMemTracking is a marker trait for types
+    // that implement Decode. The derive macro does not handle generic structs
+    // with Config bounds reliably across all codec versions.
+    impl<T: Config> codec::DecodeWithMemTracking for DidDocument<T> {}
+
+    /// A service endpoint attached to a DID document.
+    #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+    #[scale_info(skip_type_params(T))]
+    pub struct ServiceEndpoint<T: Config> {
+        /// Human-readable service type (e.g. "AgentMessaging", "RpcNode").
+        pub service_type: BoundedVec<u8, T::MaxServiceTypeLength>,
+        /// Service endpoint URL or multiaddr.
+        pub service_url: BoundedVec<u8, T::MaxServiceUrlLength>,
+    }
+
+    impl<T: Config> codec::DecodeWithMemTracking for ServiceEndpoint<T> {}
+
+    // ========== Pallet ==========
+
+    /// The pallet's configuration trait.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// The overarching runtime event type.
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+        /// Weight information for extrinsics in this pallet.
+        type WeightInfo: WeightInfo;
+
+        /// Maximum number of service endpoints per DID document.
+        #[pallet::constant]
+        type MaxServiceEndpoints: Get<u32>;
+
+        /// Maximum byte length of a service type string.
+        #[pallet::constant]
+        type MaxServiceTypeLength: Get<u32>;
+
+        /// Maximum byte length of a service URL string.
+        #[pallet::constant]
+        type MaxServiceUrlLength: Get<u32>;
+
+        /// Maximum byte length of DID document metadata.
+        #[pallet::constant]
+        type MaxMetadataLength: Get<u32>;
+    }
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
+
+    // ========== Storage ==========
+
+    /// DID documents, keyed by the account that owns them.
+    ///
+    /// `did:claw:{AccountId}` ↔ DidDocument
+    #[pallet::storage]
+    #[pallet::getter(fn did_documents)]
+    pub type DidDocuments<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::AccountId, DidDocument<T>, OptionQuery>;
+
+    /// Service endpoints attached to a DID document.
+    ///
+    /// (AccountId, ServiceEndpointId) → ServiceEndpoint
+    #[pallet::storage]
+    #[pallet::getter(fn service_endpoints)]
+    pub type ServiceEndpoints<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        Blake2_128Concat,
+        ServiceEndpointId,
+        ServiceEndpoint<T>,
+        OptionQuery,
+    >;
+
+    /// Count of active service endpoints per DID (to enforce the cap).
+    #[pallet::storage]
+    #[pallet::getter(fn service_endpoint_count)]
+    pub type ServiceEndpointCount<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
+
+    // ========== Events ==========
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// A new DID document was registered.
+        DidRegistered { who: T::AccountId },
+        /// A DID document was updated.
+        DidUpdated { who: T::AccountId },
+        /// A DID document was deactivated.
+        DidDeactivated { who: T::AccountId },
+        /// A service endpoint was added to a DID document.
+        ServiceEndpointAdded {
+            who: T::AccountId,
+            endpoint_id: ServiceEndpointId,
+        },
+        /// A service endpoint was removed from a DID document.
+        ServiceEndpointRemoved {
+            who: T::AccountId,
+            endpoint_id: ServiceEndpointId,
+        },
+    }
+
+    // ========== Errors ==========
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Caller already has a registered DID document.
+        DidAlreadyRegistered,
+        /// No DID document found for this account.
+        DidNotFound,
+        /// The DID document has been deactivated and cannot be modified.
+        DidDeactivated,
+        /// The service endpoint ID does not exist on this DID.
+        ServiceEndpointNotFound,
+        /// Maximum number of service endpoints reached.
+        TooManyServiceEndpoints,
+        /// Metadata exceeds the maximum allowed length.
+        MetadataTooLong,
+        /// Service type string exceeds the maximum allowed length.
+        ServiceTypeTooLong,
+        /// Service URL exceeds the maximum allowed length.
+        ServiceUrlTooLong,
+    }
+
+    // ========== Extrinsics ==========
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Register a new DID document for the caller.
+        ///
+        /// The DID will be `did:claw:{caller}`. Each account may only register
+        /// one DID document. The `metadata` field accepts raw bytes (e.g. JSON-LD).
+        #[pallet::call_index(0)]
+        #[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+        pub fn register_did(
+            origin: OriginFor<T>,
+            metadata: alloc::vec::Vec<u8>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            ensure!(
+                !DidDocuments::<T>::contains_key(&who),
+                Error::<T>::DidAlreadyRegistered
+            );
+
+            let bounded_metadata: BoundedVec<u8, T::MaxMetadataLength> =
+                metadata.try_into().map_err(|_| Error::<T>::MetadataTooLong)?;
+
+            let now = frame_system::Pallet::<T>::block_number();
+
+            let doc = DidDocument {
+                controller: who.clone(),
+                metadata: bounded_metadata,
+                status: DidStatus::Active,
+                registered_at: now,
+                updated_at: now,
+                next_service_id: 0,
+            };
+
+            DidDocuments::<T>::insert(&who, doc);
+
+            Self::deposit_event(Event::DidRegistered { who });
+            Ok(())
+        }
+
+        /// Update the metadata of the caller's DID document.
+        #[pallet::call_index(1)]
+        #[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+        pub fn update_did(
+            origin: OriginFor<T>,
+            new_metadata: alloc::vec::Vec<u8>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            DidDocuments::<T>::try_mutate(&who, |maybe_doc| {
+                let doc = maybe_doc.as_mut().ok_or(Error::<T>::DidNotFound)?;
+                ensure!(doc.status == DidStatus::Active, Error::<T>::DidDeactivated);
+
+                let bounded: BoundedVec<u8, T::MaxMetadataLength> =
+                    new_metadata.try_into().map_err(|_| Error::<T>::MetadataTooLong)?;
+
+                doc.metadata = bounded;
+                doc.updated_at = frame_system::Pallet::<T>::block_number();
+                Ok(())
+            })?;
+
+            Self::deposit_event(Event::DidUpdated { who });
+            Ok(())
+        }
+
+        /// Permanently deactivate the caller's DID document.
+        ///
+        /// A deactivated DID cannot be re-activated or modified. Service
+        /// endpoints may still be queried for audit purposes.
+        #[pallet::call_index(2)]
+        #[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+        pub fn deactivate_did(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            DidDocuments::<T>::try_mutate(&who, |maybe_doc| {
+                let doc = maybe_doc.as_mut().ok_or(Error::<T>::DidNotFound)?;
+                ensure!(doc.status == DidStatus::Active, Error::<T>::DidDeactivated);
+
+                doc.status = DidStatus::Deactivated;
+                doc.updated_at = frame_system::Pallet::<T>::block_number();
+                Ok(())
+            })?;
+
+            Self::deposit_event(Event::DidDeactivated { who });
+            Ok(())
+        }
+
+        /// Add a service endpoint to the caller's DID document.
+        ///
+        /// Returns the new endpoint's `ServiceEndpointId`.
+        #[pallet::call_index(3)]
+        #[pallet::weight(T::DbWeight::get().reads_writes(2, 3))]
+        pub fn add_service_endpoint(
+            origin: OriginFor<T>,
+            service_type: alloc::vec::Vec<u8>,
+            service_url: alloc::vec::Vec<u8>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            let endpoint_id = DidDocuments::<T>::try_mutate(&who, |maybe_doc| {
+                let doc = maybe_doc.as_mut().ok_or(Error::<T>::DidNotFound)?;
+                ensure!(doc.status == DidStatus::Active, Error::<T>::DidDeactivated);
+
+                let count = ServiceEndpointCount::<T>::get(&who);
+                ensure!(
+                    count < T::MaxServiceEndpoints::get(),
+                    Error::<T>::TooManyServiceEndpoints
+                );
+
+                let id = doc.next_service_id;
+                doc.next_service_id = id.saturating_add(1);
+                doc.updated_at = frame_system::Pallet::<T>::block_number();
+
+                Ok::<ServiceEndpointId, DispatchError>(id)
+            })?;
+
+            let bounded_type: BoundedVec<u8, T::MaxServiceTypeLength> =
+                service_type.try_into().map_err(|_| Error::<T>::ServiceTypeTooLong)?;
+
+            let bounded_url: BoundedVec<u8, T::MaxServiceUrlLength> =
+                service_url.try_into().map_err(|_| Error::<T>::ServiceUrlTooLong)?;
+
+            let endpoint = ServiceEndpoint {
+                service_type: bounded_type,
+                service_url: bounded_url,
+            };
+
+            ServiceEndpoints::<T>::insert(&who, endpoint_id, endpoint);
+            ServiceEndpointCount::<T>::mutate(&who, |c| *c = c.saturating_add(1));
+
+            Self::deposit_event(Event::ServiceEndpointAdded {
+                who,
+                endpoint_id,
+            });
+            Ok(())
+        }
+
+        /// Remove a service endpoint from the caller's DID document.
+        #[pallet::call_index(4)]
+        #[pallet::weight(T::DbWeight::get().reads_writes(2, 2))]
+        pub fn remove_service_endpoint(
+            origin: OriginFor<T>,
+            endpoint_id: ServiceEndpointId,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // Verify DID exists and is active.
+            let doc = DidDocuments::<T>::get(&who).ok_or(Error::<T>::DidNotFound)?;
+            ensure!(doc.status == DidStatus::Active, Error::<T>::DidDeactivated);
+
+            // Verify endpoint exists.
+            ensure!(
+                ServiceEndpoints::<T>::contains_key(&who, endpoint_id),
+                Error::<T>::ServiceEndpointNotFound
+            );
+
+            ServiceEndpoints::<T>::remove(&who, endpoint_id);
+            ServiceEndpointCount::<T>::mutate(&who, |c| *c = c.saturating_sub(1));
+
+            Self::deposit_event(Event::ServiceEndpointRemoved {
+                who,
+                endpoint_id,
+            });
+            Ok(())
+        }
+    }
+
+    // ========== Weight Trait ==========
+
+    /// Weight functions for pallet extrinsics.
+    pub trait WeightInfo {
+        fn register_did() -> Weight;
+        fn update_did() -> Weight;
+        fn deactivate_did() -> Weight;
+        fn add_service_endpoint() -> Weight;
+        fn remove_service_endpoint() -> Weight;
+    }
+
+    /// Default no-op weights (for testing / benchmarking later).
+    impl WeightInfo for () {
+        fn register_did() -> Weight { Weight::zero() }
+        fn update_did() -> Weight { Weight::zero() }
+        fn deactivate_did() -> Weight { Weight::zero() }
+        fn add_service_endpoint() -> Weight { Weight::zero() }
+        fn remove_service_endpoint() -> Weight { Weight::zero() }
+    }
+}

--- a/pallets/agent-did/src/tests.rs
+++ b/pallets/agent-did/src/tests.rs
@@ -1,0 +1,266 @@
+//! Tests for pallet-agent-did
+
+use crate::{self as pallet_agent_did, AgentDID};
+use frame_support::{
+    assert_noop, assert_ok, derive_impl,
+    traits::ConstU32,
+    BoundedVec,
+};
+use frame_support::sp_runtime::BuildStorage;
+use sp_runtime::traits::IdentityLookup;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+    pub enum Test {
+        System: frame_system,
+        AgentDid: pallet_agent_did,
+    }
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+}
+
+impl pallet_agent_did::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type MaxEndpoints = ConstU32<10>;
+    type MaxFieldLen = ConstU32<256>;
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+    frame_system::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap()
+        .into()
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn mk_bounded(s: &[u8]) -> BoundedVec<u8, ConstU32<256>> {
+    BoundedVec::try_from(s.to_vec()).unwrap()
+}
+
+fn mk_ep(id: &[u8]) -> crate::pallet::ServiceEndpoint {
+    crate::pallet::ServiceEndpoint {
+        id: mk_bounded(id),
+        endpoint_type: mk_bounded(b"LinkedDomains"),
+        url: mk_bounded(b"https://example.com"),
+    }
+}
+
+fn mk_eps(ids: &[&[u8]]) -> BoundedVec<crate::pallet::ServiceEndpoint, ConstU32<10>> {
+    BoundedVec::try_from(ids.iter().map(|id| mk_ep(id)).collect::<Vec<_>>()).unwrap()
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn register_did_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        let doc = AgentDID::<Test>::get(1).expect("DID should exist");
+        assert_eq!(doc.controller, 1u64);
+        assert_eq!(doc.service_endpoints.len(), 0);
+    });
+}
+
+#[test]
+fn register_did_stores_endpoints() {
+    new_test_ext().execute_with(|| {
+        let eps = mk_eps(&[b"svc-1", b"svc-2"]);
+        assert_ok!(AgentDid::register_did(RuntimeOrigin::signed(1), eps));
+        let doc = AgentDID::<Test>::get(1).unwrap();
+        assert_eq!(doc.service_endpoints.len(), 2);
+    });
+}
+
+#[test]
+fn register_did_fails_if_already_registered() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert_noop!(
+            AgentDid::register_did(RuntimeOrigin::signed(1), BoundedVec::default()),
+            crate::Error::<Test>::AlreadyRegistered
+        );
+    });
+}
+
+#[test]
+fn update_did_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        let eps = mk_eps(&[b"svc-new"]);
+        assert_ok!(AgentDid::update_did(RuntimeOrigin::signed(1), eps));
+        let doc = AgentDID::<Test>::get(1).unwrap();
+        assert_eq!(doc.service_endpoints.len(), 1);
+        assert_eq!(doc.service_endpoints[0].id.as_slice(), b"svc-new");
+    });
+}
+
+#[test]
+fn update_did_fails_if_not_registered() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            AgentDid::update_did(RuntimeOrigin::signed(2), BoundedVec::default()),
+            crate::Error::<Test>::NotRegistered
+        );
+    });
+}
+
+#[test]
+fn deactivate_did_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert_ok!(AgentDid::deactivate_did(RuntimeOrigin::signed(1)));
+        assert!(!AgentDID::<Test>::contains_key(1));
+    });
+}
+
+#[test]
+fn deactivate_did_fails_if_not_registered() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            AgentDid::deactivate_did(RuntimeOrigin::signed(3)),
+            crate::Error::<Test>::NotRegistered
+        );
+    });
+}
+
+#[test]
+fn add_service_endpoint_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert_ok!(AgentDid::add_service_endpoint(
+            RuntimeOrigin::signed(1),
+            mk_bounded(b"svc-1"),
+            mk_bounded(b"LinkedDomains"),
+            mk_bounded(b"https://example.com"),
+        ));
+        let doc = AgentDID::<Test>::get(1).unwrap();
+        assert_eq!(doc.service_endpoints.len(), 1);
+        assert_eq!(doc.service_endpoints[0].id.as_slice(), b"svc-1");
+    });
+}
+
+#[test]
+fn remove_service_endpoint_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert_ok!(AgentDid::add_service_endpoint(
+            RuntimeOrigin::signed(1),
+            mk_bounded(b"svc-1"),
+            mk_bounded(b"LinkedDomains"),
+            mk_bounded(b"https://example.com"),
+        ));
+        assert_ok!(AgentDid::remove_service_endpoint(
+            RuntimeOrigin::signed(1),
+            mk_bounded(b"svc-1"),
+        ));
+        let doc = AgentDID::<Test>::get(1).unwrap();
+        assert_eq!(doc.service_endpoints.len(), 0);
+    });
+}
+
+#[test]
+fn remove_endpoint_fails_if_not_found() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert_noop!(
+            AgentDid::remove_service_endpoint(
+                RuntimeOrigin::signed(1),
+                mk_bounded(b"nonexistent"),
+            ),
+            crate::Error::<Test>::EndpointNotFound
+        );
+    });
+}
+
+#[test]
+fn too_many_endpoints_rejected() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        // Fill up to MaxEndpoints (10)
+        for i in 0u8..10 {
+            assert_ok!(AgentDid::add_service_endpoint(
+                RuntimeOrigin::signed(1),
+                BoundedVec::try_from(vec![i]).unwrap(),
+                mk_bounded(b"type"),
+                mk_bounded(b"https://example.com"),
+            ));
+        }
+        // 11th should fail
+        assert_noop!(
+            AgentDid::add_service_endpoint(
+                RuntimeOrigin::signed(1),
+                mk_bounded(b"overflow"),
+                mk_bounded(b"type"),
+                mk_bounded(b"https://example.com"),
+            ),
+            crate::Error::<Test>::TooManyEndpoints
+        );
+    });
+}
+
+#[test]
+fn add_endpoint_fails_if_not_registered() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            AgentDid::add_service_endpoint(
+                RuntimeOrigin::signed(99),
+                mk_bounded(b"svc-1"),
+                mk_bounded(b"LinkedDomains"),
+                mk_bounded(b"https://example.com"),
+            ),
+            crate::Error::<Test>::NotRegistered
+        );
+    });
+}
+
+#[test]
+fn did_can_be_re_registered_after_deactivation() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert_ok!(AgentDid::deactivate_did(RuntimeOrigin::signed(1)));
+        // Should be able to re-register after deactivation
+        assert_ok!(AgentDid::register_did(
+            RuntimeOrigin::signed(1),
+            BoundedVec::default()
+        ));
+        assert!(AgentDID::<Test>::contains_key(1));
+    });
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -66,6 +66,8 @@ pallet-agent-registry = { workspace = true }
 pallet-claw-token = { workspace = true }
 pallet-reputation = { workspace = true }
 pallet-task-market = { workspace = true }
+pallet-gas-quota = { workspace = true }
+pallet-agent-did = { workspace = true }
 pallet-rpc-registry = { workspace = true }
 
 [build-dependencies]
@@ -121,6 +123,7 @@ std = [
     "pallet-reputation/std",
     "pallet-task-market/std",
     "pallet-rpc-registry/std",
+    "pallet-agent-did/std",
     "substrate-wasm-builder",
 ]
 runtime-benchmarks = [
@@ -139,6 +142,7 @@ runtime-benchmarks = [
     "pallet-reputation/runtime-benchmarks",
     "pallet-task-market/runtime-benchmarks",
     "pallet-rpc-registry/runtime-benchmarks",
+    "pallet-agent-did/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
@@ -165,4 +169,5 @@ try-runtime = [
     "pallet-reputation/try-runtime",
     "pallet-task-market/try-runtime",
     "pallet-rpc-registry/try-runtime",
+    "pallet-agent-did/try-runtime",
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -520,6 +520,31 @@ impl pallet_rpc_registry::Config for Runtime {
     type MaxHeartbeatInterval = ConstU32<300>; // 300 blocks = ~30 min at 6s/block
 }
 // Create the runtime by composing the FRAME pallets that were previously configured.
+parameter_types! {
+    pub const GasQuotaBlocksPerDay: u32 = 14_400; // 6s blocks × 14400 = 24h
+    pub const GasQuotaStakePerFreeTx: u128 = 1_000_000_000_000; // 1 CLAW
+    pub const GasQuotaUnlimitedThreshold: u128 = 10_000_000_000_000_000; // 10,000 CLAW
+    pub const GasQuotaBaseFee: u128 = 1_000_000_000; // 0.001 CLAW
+    pub const GasQuotaFeeDiscount: sp_runtime::Perbill = sp_runtime::Perbill::from_percent(90);
+    pub const GasQuotaMinFree: u32 = 10;
+}
+
+impl pallet_gas_quota::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type Currency = Balances;
+    type BlocksPerDay = GasQuotaBlocksPerDay;
+    type MinFreeQuota = GasQuotaMinFree;
+    type StakePerFreeTx = GasQuotaStakePerFreeTx;
+    type UnlimitedStakeThreshold = GasQuotaUnlimitedThreshold;
+    type BaseFeePerTx = GasQuotaBaseFee;
+    type FeeDiscountPerKStake = GasQuotaFeeDiscount;
+}
+impl pallet_agent_did::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type MaxEndpoints = frame_support::traits::ConstU32<10>;
+    type MaxFieldLen = frame_support::traits::ConstU32<256>;
+}
+
 frame_support::construct_runtime!(
     pub enum Runtime {
         System: frame_system,
@@ -545,6 +570,8 @@ frame_support::construct_runtime!(
         Reputation: pallet_reputation,
         TaskMarket: pallet_task_market,
         RpcRegistry: pallet_rpc_registry,
+        GasQuota: pallet_gas_quota,
+        AgentDid: pallet_agent_did,
     }
 );
 


### PR DESCRIPTION
## Summary

Implements ADR-003: Decentralized Identifier (DID) management for ClawChain agents.

### What's included:
- **New pallet:** `pallet-agent-did` at `pallets/agent-did/`
- **DID format:** `did:claw:{agent_address}`
- **Storage:** `AgentDID` map (`AccountId -> DIDDocument`)
- **DIDDocument** contains: controller, service_endpoints (BoundedVec), created_at, updated_at
- **ServiceEndpoint** struct: id, endpoint_type, url (each BoundedVec<u8, 256>)
- **Constants:** MaxEndpoints=10, MaxFieldLen=256

### Extrinsics:
- `register_did(service_endpoints)` — Register a new DID
- `update_did(service_endpoints)` — Replace all endpoints
- `deactivate_did()` — Remove DID document
- `add_service_endpoint(id, type, url)` — Add single endpoint
- `remove_service_endpoint(id)` — Remove endpoint by id

### Tests:
15 tests covering all extrinsics, error paths (AlreadyRegistered, NotRegistered, EndpointNotFound, TooManyEndpoints), and re-registration after deactivation.

### Integration:
- Added to workspace Cargo.toml
- Added to runtime/Cargo.toml and runtime/src/lib.rs
- Follows same pattern as pallet-gas-quota

Closes #30