### PR TITLE
feat: deploy ClawChain block explorer

### DIFF
--- a/services/explorer/src/test/components/BlockDetail.test.tsx
+++ b/services/explorer/src/test/components/BlockDetail.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BlockDetail } from '@/components/BlockDetail';
+import type { BlockInfo } from '@/lib/types';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: vi.fn() }),
+}));
+
+const HASH = '0x' + 'a'.repeat(64);
+const PARENT = '0x' + 'b'.repeat(64);
+const STATE = '0x' + 'c'.repeat(64);
+const EXTR_ROOT = '0x' + 'd'.repeat(64);
+const TX_HASH = '0x' + 'e'.repeat(64);
+const SIGNER = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
+const mockBlock: BlockInfo = {
+  hash: HASH,
+  number: 100,
+  timestamp: 1700000000000,
+  extrinsicCount: 1,
+  producer: SIGNER,
+  parentHash: PARENT,
+  stateRoot: STATE,
+  extrinsicsRoot: EXTR_ROOT,
+  extrinsics: [
+    {
+      hash: TX_HASH,
+      index: 0,
+      section: 'balances',
+      method: 'transfer',
+      signer: SIGNER,
+      success: true,
+    },
+  ],
+};
+
+describe('BlockDetail', () => {
+  it('shows loading state', () => {
+    render(<BlockDetail data={null} loading={true} error={null} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    render(<BlockDetail data={null} loading={false} error="Block not found on chain" />);
+    expect(screen.getByText('Block not found on chain')).toBeInTheDocument();
+  });
+
+  it('shows "Block not found" when data is null and no error', () => {
+    render(<BlockDetail data={null} loading={false} error={null} />);
+    expect(screen.getByText('Block not found')).toBeInTheDocument();
+  });
+
+  it('renders block number in heading', () => {
+    render(<BlockDetail data={mockBlock} loading={false} error={null} />);
+    expect(screen.getByText('#100')).toBeInTheDocument();
+  });
+
+  it('renders block hash', () => {
+    render(<BlockDetail data={mockBlock} loading={false} error={null} />);
+    expect(screen.getByText(HASH)).toBeInTheDocument();
+  });
+
+  it('renders parent hash as link', () => {
+    render(<BlockDetail data={mockBlock} loading={false} error={null} />);
+    const parentLink = screen.getByRole('link', { name: /0xbbbb/ });
+    expect(parentLink).toHaveAttribute('href', `/blocks/${PARENT}`);
+  });
+
+  it('renders extrinsics table with success badge', () => {
+    render(<BlockDetail data={mockBlock} loading={false} error={null} />);
+    expect(screen.getByRole('table', { name: /extrinsics/i })).toBeInTheDocument();
+    expect(screen.getByText('✓ Success')).toBeInTheDocument();
+    expect(screen.getByText('balances.transfer')).toBeInTheDocument();
+  });
+
+  it('renders failed extrinsic badge', () => {
+    const failBlock: BlockInfo = {
+      ...mockBlock,
+      extrinsics: [{ ...mockBlock.extrinsics[0]!, success: false }],
+    };
+    render(<BlockDetail data={failBlock} loading={false} error={null} />);
+    expect(screen.getByText('✗ Failed')).toBeInTheDocument();
+  });
+
+  it('renders unsigned extrinsic (no signer) with dash', () => {
+    const unsignedBlock: BlockInfo = {
+      ...mockBlock,
+      extrinsics: [{ ...mockBlock.extrinsics[0]!, signer: null }],
+    };
+    render(<BlockDetail data={unsignedBlock} loading={false} error={null} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders "Unknown" producer when producer is empty', () => {
+    const noProducerBlock: BlockInfo = { ...mockBlock, producer: '' };
+    render(<BlockDetail data={noProducerBlock} loading={false} error={null} />);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('renders producer as link to agent profile', () => {
+    render(<BlockDetail data={mockBlock} loading={false} error={null} />);
+    // Both producer row and signer column in extrinsics table link to the same agent
+    const agentLinks = screen.getAllByRole('link', { name: /5Grwva/ });
+    expect(agentLinks.length).toBeGreaterThan(0);
+    agentLinks.forEach(link => {
+      expect(link).toHaveAttribute('href', `/agents/${SIGNER}`);
+    });
+  });
+
+  it('renders tx hash as link to tx detail', () => {
+    render(<BlockDetail data={mockBlock} loading={false} error={null} />);
+    const txLink = screen.getByRole('link', { name: /0xeeee/ });
+    expect(txLink).toHaveAttribute('href', `/tx/${TX_HASH}`);
+  });
+
+  it('renders zero timestamp as "Unknown"', () => {
+    const noTsBlock: BlockInfo = { ...mockBlock, timestamp: 0 };
+    render(<BlockDetail data={noTsBlock} loading={false} error={null} />);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('renders block with no extrinsics — no table rendered', () => {
+    const emptyBlock: BlockInfo = { ...mockBlock, extrinsics: [], extrinsicCount: 0 };
+    render(<BlockDetail data={emptyBlock} loading={false} error={null} />);
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+});

--- a/services/explorer/src/test/components/Header.test.tsx
+++ b/services/explorer/src/test/components/Header.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Header } from '@/components/Header';
+import type { ConnectionStatus } from '@/lib/types';
+
+// Mock useApi hook
+vi.mock('@/hooks/useApi', () => ({
+  useApi: vi.fn(),
+}));
+
+// Mock next/link to render a plain anchor
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+// Mock LiveIndicator to avoid its internals
+vi.mock('@/components/LiveIndicator', () => ({
+  LiveIndicator: ({ status }: { status: ConnectionStatus }) => (
+    <span data-testid="live-indicator" data-status={status}>{status}</span>
+  ),
+}));
+
+import { useApi } from '@/hooks/useApi';
+
+const mockUseApi = vi.mocked(useApi);
+
+describe('Header', () => {
+  it('renders logo and nav links', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'connecting', blockNumber: null });
+    render(<Header />);
+
+    expect(screen.getByText(/ClawChain/)).toBeInTheDocument();
+    expect(screen.getByText('Explorer')).toBeInTheDocument();
+    expect(screen.getByText('Blocks')).toBeInTheDocument();
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+  });
+
+  it('shows block number when available', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'connected', blockNumber: 12345 });
+    render(<Header />);
+
+    expect(screen.getByText(/#12,345|#12345/)).toBeInTheDocument();
+  });
+
+  it('hides block number when null', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'connected', blockNumber: null });
+    render(<Header />);
+
+    // No block number text
+    expect(screen.queryByText(/#\d/)).toBeNull();
+  });
+
+  it('passes connection status to LiveIndicator', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'disconnected', blockNumber: null });
+    render(<Header />);
+
+    const indicator = screen.getByTestId('live-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'disconnected');
+  });
+
+  it('passes error status to LiveIndicator', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'error', blockNumber: null });
+    render(<Header />);
+
+    const indicator = screen.getByTestId('live-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'error');
+  });
+
+  it('logo links to /blocks', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'connected', blockNumber: null });
+    render(<Header />);
+
+    const logoLink = screen.getByText(/ClawChain/).closest('a');
+    expect(logoLink).toHaveAttribute('href', '/blocks');
+  });
+
+  it('Blocks nav link points to /blocks', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'connected', blockNumber: null });
+    render(<Header />);
+
+    const blocksLink = screen.getByText('Blocks').closest('a');
+    expect(blocksLink).toHaveAttribute('href', '/blocks');
+  });
+
+  it('Agents nav link points to /agents', () => {
+    mockUseApi.mockReturnValue({ api: null, status: 'connected', blockNumber: null });
+    render(<Header />);
+
+    const agentsLink = screen.getByText('Agents').closest('a');
+    expect(agentsLink).toHaveAttribute('href', '/agents');
+  });
+});

--- a/services/explorer/src/test/components/TxDetail.test.tsx
+++ b/services/explorer/src/test/components/TxDetail.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TxDetail } from '@/components/TxDetail';
+import type { ExtrinsicInfo } from '@/lib/types';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: vi.fn() }),
+}));
+
+const BLOCK_HASH = '0x' + 'b'.repeat(64);
+const TX_HASH = '0x' + 'a'.repeat(64);
+const SIGNER = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
+const mockTx: ExtrinsicInfo = {
+  hash: TX_HASH,
+  index: 0,
+  section: 'balances',
+  method: 'transfer',
+  signer: SIGNER,
+  success: true,
+  blockHash: BLOCK_HASH,
+  blockNumber: 100,
+  args: { dest: '5Dest...', value: '1000' },
+  events: [
+    { section: 'system', method: 'ExtrinsicSuccess', data: { weight: '100' } },
+  ],
+  tip: '0',
+  fee: '1000000000000',
+};
+
+describe('TxDetail', () => {
+  it('shows loading state', () => {
+    render(<TxDetail data={null} loading={true} error={null} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    render(<TxDetail data={null} loading={false} error="Transaction not found in recent blocks" />);
+    expect(screen.getByText('Transaction not found in recent blocks')).toBeInTheDocument();
+  });
+
+  it('shows "Transaction not found" when data is null', () => {
+    render(<TxDetail data={null} loading={false} error={null} />);
+    expect(screen.getByText('Transaction not found')).toBeInTheDocument();
+  });
+
+  it('renders tx hash', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    expect(screen.getByText(TX_HASH)).toBeInTheDocument();
+  });
+
+  it('renders success badge for successful tx', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    expect(screen.getByText('✓ Success')).toBeInTheDocument();
+  });
+
+  it('renders failed badge for failed tx', () => {
+    const failedTx: ExtrinsicInfo = { ...mockTx, success: false };
+    render(<TxDetail data={failedTx} loading={false} error={null} />);
+    expect(screen.getByText('✗ Failed')).toBeInTheDocument();
+  });
+
+  it('renders call as section.method', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    expect(screen.getByText('balances.transfer')).toBeInTheDocument();
+  });
+
+  it('renders block number as link', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    const blockLink = screen.getByRole('link', { name: /#100/ });
+    expect(blockLink).toHaveAttribute('href', `/blocks/${BLOCK_HASH}`);
+  });
+
+  it('renders signer as link to agent profile', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    const signerLink = screen.getByRole('link', { name: /5Grwva/ });
+    expect(signerLink).toHaveAttribute('href', `/agents/${SIGNER}`);
+  });
+
+  it('renders "Unsigned" when signer is null', () => {
+    const unsignedTx: ExtrinsicInfo = { ...mockTx, signer: null };
+    render(<TxDetail data={unsignedTx} loading={false} error={null} />);
+    expect(screen.getByText('Unsigned')).toBeInTheDocument();
+  });
+
+  it('renders arguments as JSON', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    expect(screen.getByText('Arguments')).toBeInTheDocument();
+    // JSON.stringify output of args
+    const pre = screen.getByText(/dest/);
+    expect(pre).toBeInTheDocument();
+  });
+
+  it('renders events section', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    expect(screen.getByText('Events (1)')).toBeInTheDocument();
+    expect(screen.getByText('system.ExtrinsicSuccess')).toBeInTheDocument();
+  });
+
+  it('does not render Arguments section when args is empty', () => {
+    const noArgsTx: ExtrinsicInfo = { ...mockTx, args: {} };
+    render(<TxDetail data={noArgsTx} loading={false} error={null} />);
+    expect(screen.queryByText('Arguments')).toBeNull();
+  });
+
+  it('does not render Events section when events is empty', () => {
+    const noEventsTx: ExtrinsicInfo = { ...mockTx, events: [] };
+    render(<TxDetail data={noEventsTx} loading={false} error={null} />);
+    expect(screen.queryByText(/Events \(/)).toBeNull();
+  });
+
+  it('renders fee and tip formatted as CLAW', () => {
+    render(<TxDetail data={mockTx} loading={false} error={null} />);
+    // Both fee and tip rows show CLAW amounts — both display as 0.0000 CLAW
+    const clawElements = screen.getAllByText(/CLAW/);
+    expect(clawElements.length).toBeGreaterThanOrEqual(2); // Fee row + Tip row
+  });
+
+  it('renders multiple events', () => {
+    const multiEventTx: ExtrinsicInfo = {
+      ...mockTx,
+      events: [
+        { section: 'system', method: 'ExtrinsicSuccess', data: {} },
+        { section: 'balances', method: 'Transfer', data: { from: '5A', to: '5B' } },
+      ],
+    };
+    render(<TxDetail data={multiEventTx} loading={false} error={null} />);
+    expect(screen.getByText('Events (2)')).toBeInTheDocument();
+    expect(screen.getByText('system.ExtrinsicSuccess')).toBeInTheDocument();
+    expect(screen.getByText('balances.Transfer')).toBeInTheDocument();
+  });
+});

--- a/services/explorer/src/test/hooks/useAgent.test.ts
+++ b/services/explorer/src/test/hooks/useAgent.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useAgent } from '@/hooks/useAgent';
+import { ApiContext } from '@/providers/ApiProvider';
+import type { ApiPromise } from '@polkadot/api';
+import type { ConnectionStatus } from '@/lib/types';
+
+// Valid SS58 address (48 chars — within 32-60 range)
+const VALID_ADDR = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
+function makeWrapper(api: ApiPromise | null) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      ApiContext.Provider,
+      { value: { api, status: 'connected' as ConnectionStatus, blockNumber: 1 } },
+      children,
+    );
+  };
+}
+
+describe('useAgent', () => {
+  it('stays loading when api is null', () => {
+    const wrapper = makeWrapper(null);
+    const { result } = renderHook(() => useAgent(VALID_ADDR), { wrapper });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error for address too short (< 32 chars)', async () => {
+    const mockApi = {} as unknown as ApiPromise;
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useAgent('abc'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/Invalid address/);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns error for address too long (> 60 chars)', async () => {
+    const longAddr = 'a'.repeat(61);
+    const mockApi = {} as unknown as ApiPromise;
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useAgent(longAddr), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/Invalid address/);
+  });
+
+  it('fetches agent data with all pallets available', async () => {
+    const mockAgentIds = { toJSON: () => ['agent-id-1'] };
+    const mockAgentDetails = { toHuman: () => ({ did: 'did:claw:test-agent' }) };
+    const mockRep = { toJSON: () => 85 };
+    const mockRepHistory = { toJSON: () => [{ block: 100, score: 80 }] };
+    const mockQuota = {
+      toJSON: () => ({
+        remaining: '500000000000000000',
+        total: '1000000000000000000',
+        lastRefill: 150,
+      }),
+    };
+
+    const mockApi = {
+      query: {
+        agentRegistry: {
+          ownerAgents: vi.fn().mockResolvedValue(mockAgentIds),
+          agentRegistry: vi.fn().mockResolvedValue(mockAgentDetails),
+        },
+        reputation: {
+          reputations: vi.fn().mockResolvedValue(mockRep),
+          reputationHistory: vi.fn().mockResolvedValue(mockRepHistory),
+        },
+        gasQuota: {
+          agentQuotas: vi.fn().mockResolvedValue(mockQuota),
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useAgent(VALID_ADDR), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.did).toBe('did:claw:test-agent');
+    expect(result.current.data?.reputation).toBe(85);
+    expect(result.current.data?.reputationHistory).toHaveLength(1);
+    expect(result.current.data?.reputationHistory[0]?.block).toBe(100);
+    expect(result.current.data?.gasQuota?.remaining).toBe('500000000000000000');
+    expect(result.current.data?.gasQuota?.total).toBe('1000000000000000000');
+    expect(result.current.data?.gasQuota?.lastRefill).toBe(150);
+  });
+
+  it('returns data with null fields when all pallets are missing', async () => {
+    // Query object has no pallet keys — optional chaining returns undefined for all
+    const mockApi = {
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useAgent(VALID_ADDR), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.did).toBeNull();
+    expect(result.current.data?.reputation).toBeNull();
+    expect(result.current.data?.gasQuota).toBeNull();
+    expect(result.current.data?.reputationHistory).toEqual([]);
+  });
+
+  it('handles pallets that reject — all fields remain null', async () => {
+    const mockApi = {
+      query: {
+        agentRegistry: {
+          ownerAgents: vi.fn().mockRejectedValue(new Error('pallet not found')),
+          agentRegistry: vi.fn().mockRejectedValue(new Error('pallet not found')),
+        },
+        reputation: {
+          reputations: vi.fn().mockRejectedValue(new Error('not found')),
+          reputationHistory: vi.fn().mockRejectedValue(new Error('not found')),
+        },
+        gasQuota: {
+          agentQuotas: vi.fn().mockRejectedValue(new Error('not found')),
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useAgent(VALID_ADDR), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data?.did).toBeNull();
+    expect(result.current.data?.reputation).toBeNull();
+    expect(result.current.data?.gasQuota).toBeNull();
+  });
+
+  it('fetches agent with no owned agents — did remains null', async () => {
+    // ownerAgents returns empty list
+    const mockAgentIds = { toJSON: () => [] };
+    const mockRep = { toJSON: () => null };
+    const mockRepHistory = { toJSON: () => [] };
+    const mockQuota = { toJSON: () => null };
+
+    const mockApi = {
+      query: {
+        agentRegistry: {
+          ownerAgents: vi.fn().mockResolvedValue(mockAgentIds),
+          agentRegistry: vi.fn().mockResolvedValue(null),
+        },
+        reputation: {
+          reputations: vi.fn().mockResolvedValue(mockRep),
+          reputationHistory: vi.fn().mockResolvedValue(mockRepHistory),
+        },
+        gasQuota: {
+          agentQuotas: vi.fn().mockResolvedValue(mockQuota),
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useAgent(VALID_ADDR), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data?.did).toBeNull();
+    expect(result.current.data?.reputation).toBeNull();
+    expect(result.current.data?.reputationHistory).toEqual([]);
+    expect(result.current.data?.gasQuota).toBeNull();
+  });
+
+  it('sets loading and clears previous data when address changes', async () => {
+    const mockApi = {
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result, rerender } = renderHook(
+      ({ address }: { address: string }) => useAgent(address),
+      { wrapper, initialProps: { address: VALID_ADDR } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Change address — hook should reload
+    rerender({ address: VALID_ADDR.replace('5', '6') });
+    // Should start loading again (or settle quickly since it's the same mock)
+    expect(result.current).toBeDefined();
+  });
+});

--- a/services/explorer/src/test/hooks/useBlock.test.ts
+++ b/services/explorer/src/test/hooks/useBlock.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useBlock } from '@/hooks/useBlock';
+import { ApiContext } from '@/providers/ApiProvider';
+import type { ApiPromise } from '@polkadot/api';
+import type { ConnectionStatus } from '@/lib/types';
+
+const BLOCK_HASH = '0x' + 'a'.repeat(64);
+const PARENT_HASH = '0x' + 'b'.repeat(64);
+const STATE_ROOT = '0x' + 'c'.repeat(64);
+const EXTR_ROOT = '0x' + 'd'.repeat(64);
+const TX_HASH = '0x' + 'e'.repeat(64);
+
+function makeWrapper(api: ApiPromise | null) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      ApiContext.Provider,
+      { value: { api, status: 'connected' as ConnectionStatus, blockNumber: null } },
+      children,
+    );
+  };
+}
+
+function makeMockBlock(extrinsics: unknown[] = []) {
+  return {
+    block: {
+      header: {
+        number: { toNumber: () => 100 },
+        parentHash: { toHex: () => PARENT_HASH },
+        stateRoot: { toHex: () => STATE_ROOT },
+        extrinsicsRoot: { toHex: () => EXTR_ROOT },
+      },
+      extrinsics,
+    },
+  };
+}
+
+describe('useBlock', () => {
+  it('stays loading when api is null', () => {
+    const wrapper = makeWrapper(null);
+    const { result } = renderHook(() => useBlock(BLOCK_HASH), { wrapper });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error for invalid input (not a number or hash)', async () => {
+    const mockApi = {
+      rpc: { chain: { getBlock: vi.fn(), getBlockHash: vi.fn() } },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useBlock('not-valid'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/Invalid block hash or number/);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('fetches block by hash — full data with timestamp and events', async () => {
+    const mockExtrinsic = {
+      hash: { toHex: () => TX_HASH },
+      method: { section: 'balances', method: 'transfer' },
+      isSigned: true,
+      signer: { toString: () => '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY' },
+    };
+
+    const mockEvents = [
+      {
+        phase: {
+          isApplyExtrinsic: true,
+          asApplyExtrinsic: { toNumber: () => 0 },
+        },
+        event: { section: 'system', method: 'ExtrinsicSuccess' },
+      },
+    ];
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          getBlock: vi.fn().mockResolvedValue(makeMockBlock([mockExtrinsic])),
+        },
+      },
+      query: {
+        timestamp: {
+          now: {
+            at: vi.fn().mockResolvedValue({ toString: () => '1700000000000' }),
+          },
+        },
+        system: {
+          events: {
+            at: vi.fn().mockResolvedValue({ toHuman: () => mockEvents }),
+          },
+        },
+        session: {
+          validators: {
+            at: vi.fn().mockResolvedValue({
+              toJSON: () => ['5ValidatorAddr1', '5ValidatorAddr2'],
+            }),
+          },
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useBlock(BLOCK_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    const data = result.current.data;
+    expect(data).not.toBeNull();
+    expect(data?.hash).toBe(BLOCK_HASH);
+    expect(data?.number).toBe(100);
+    expect(data?.timestamp).toBe(1700000000000);
+    expect(data?.parentHash).toBe(PARENT_HASH);
+    expect(data?.stateRoot).toBe(STATE_ROOT);
+    expect(data?.extrinsicsRoot).toBe(EXTR_ROOT);
+    expect(data?.extrinsics).toHaveLength(1);
+    expect(data?.extrinsics[0]?.section).toBe('balances');
+    expect(data?.extrinsics[0]?.success).toBe(true);
+    expect(data?.producer).toBeTruthy();
+  });
+
+  it('fetches block by number — calls getBlockHash first', async () => {
+    const mockApi = {
+      rpc: {
+        chain: {
+          getBlockHash: vi.fn().mockResolvedValue({ toHex: () => BLOCK_HASH }),
+          getBlock: vi.fn().mockResolvedValue(makeMockBlock([])),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useBlock('100'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data?.number).toBe(100);
+    expect(mockApi.rpc.chain.getBlockHash).toHaveBeenCalledWith(100);
+  });
+
+  it('marks extrinsic as failed when ExtrinsicFailed event present', async () => {
+    const mockExtrinsic = {
+      hash: { toHex: () => TX_HASH },
+      method: { section: 'system', method: 'remark' },
+      isSigned: false,
+      signer: null,
+    };
+
+    const failEvents = [
+      {
+        phase: {
+          isApplyExtrinsic: true,
+          asApplyExtrinsic: { toNumber: () => 0 },
+        },
+        event: { section: 'system', method: 'ExtrinsicFailed' },
+      },
+    ];
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          getBlock: vi.fn().mockResolvedValue(makeMockBlock([mockExtrinsic])),
+        },
+      },
+      query: {
+        system: {
+          events: {
+            at: vi.fn().mockResolvedValue({ toHuman: () => failEvents }),
+          },
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useBlock(BLOCK_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data?.extrinsics[0]?.success).toBe(false);
+    expect(result.current.data?.extrinsics[0]?.signer).toBeNull();
+  });
+
+  it('returns error when API throws', async () => {
+    const mockApi = {
+      rpc: {
+        chain: {
+          getBlock: vi.fn().mockRejectedValue(new Error('RPC failed')),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useBlock(BLOCK_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('RPC failed');
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/services/explorer/src/test/hooks/useNewHeads.test.ts
+++ b/services/explorer/src/test/hooks/useNewHeads.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useNewHeads } from '@/hooks/useNewHeads';
+import { ApiContext } from '@/providers/ApiProvider';
+import type { ApiPromise } from '@polkadot/api';
+import type { ConnectionStatus } from '@/lib/types';
+
+function makeWrapper(api: ApiPromise | null) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      ApiContext.Provider,
+      { value: { api, status: 'connected' as ConnectionStatus, blockNumber: null } },
+      children,
+    );
+  };
+}
+
+describe('useNewHeads', () => {
+  it('stays loading when api is null', () => {
+    const wrapper = makeWrapper(null);
+    const { result } = renderHook(() => useNewHeads(), { wrapper });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.blocks).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('receives new blocks and sets loading=false', async () => {
+    const mockHeader = {
+      hash: { toHex: () => '0x' + 'a'.repeat(64) },
+      number: { toNumber: () => 42 },
+    };
+
+    const mockBlock = {
+      block: { extrinsics: [{}, {}] },
+    };
+
+    // subscribeNewHeads calls callback once synchronously, then returns unsub
+    const mockSubscribeNewHeads = vi.fn().mockImplementation(async (callback: (h: typeof mockHeader) => Promise<void>) => {
+      await callback(mockHeader);
+      return vi.fn();
+    });
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          subscribeNewHeads: mockSubscribeNewHeads,
+          getBlock: vi.fn().mockResolvedValue(mockBlock),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useNewHeads(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.blocks).toHaveLength(1);
+    expect(result.current.blocks[0]?.number).toBe(42);
+    expect(result.current.blocks[0]?.extrinsicCount).toBe(2);
+    expect(result.current.blocks[0]?.hash).toBe('0x' + 'a'.repeat(64));
+  });
+
+  it('includes producer when session validators available', async () => {
+    const mockHeader = {
+      hash: { toHex: () => '0x' + 'a'.repeat(64) },
+      number: { toNumber: () => 0 },
+    };
+
+    const mockBlock = { block: { extrinsics: [] } };
+
+    const mockSubscribeNewHeads = vi.fn().mockImplementation(async (callback: (h: typeof mockHeader) => Promise<void>) => {
+      await callback(mockHeader);
+      return vi.fn();
+    });
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          subscribeNewHeads: mockSubscribeNewHeads,
+          getBlock: vi.fn().mockResolvedValue(mockBlock),
+        },
+      },
+      query: {
+        timestamp: {
+          now: {
+            at: vi.fn().mockResolvedValue({ toString: () => '1700000000000' }),
+          },
+        },
+        session: {
+          validators: {
+            at: vi.fn().mockResolvedValue({
+              toJSON: () => ['5ValidatorAddr1'],
+            }),
+          },
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useNewHeads(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.blocks[0]?.producer).toBe('5ValidatorAddr1');
+    expect(result.current.blocks[0]?.timestamp).toBe(1700000000000);
+  });
+
+  it('returns error when subscription throws', async () => {
+    const mockApi = {
+      rpc: {
+        chain: {
+          subscribeNewHeads: vi.fn().mockRejectedValue(new Error('subscribe failed')),
+          getBlock: vi.fn(),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useNewHeads(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('subscribe failed');
+    expect(result.current.blocks).toEqual([]);
+  });
+
+  it('accumulates multiple blocks up to MAX_BLOCKS (50)', async () => {
+    const mockBlock = { block: { extrinsics: [] } };
+
+    let callCount = 0;
+    const mockSubscribeNewHeads = vi.fn().mockImplementation(
+      async (callback: (h: { hash: { toHex: () => string }; number: { toNumber: () => number } }) => Promise<void>) => {
+        // Fire 3 block callbacks
+        for (let i = 0; i < 3; i++) {
+          const num = i + 1;
+          await callback({
+            hash: { toHex: () => `0x${String(num).padStart(64, '0')}` },
+            number: { toNumber: () => num },
+          });
+          callCount++;
+        }
+        return vi.fn();
+      },
+    );
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          subscribeNewHeads: mockSubscribeNewHeads,
+          getBlock: vi.fn().mockResolvedValue(mockBlock),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useNewHeads(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.blocks.length).toBe(3);
+    });
+
+    expect(callCount).toBe(3);
+    // Blocks are prepended, so first block is the most recent (num=3)
+    expect(result.current.blocks[0]?.number).toBe(3);
+    expect(result.current.blocks[2]?.number).toBe(1);
+  });
+
+  it('calls unsub when component unmounts', async () => {
+    const mockUnsub = vi.fn();
+    const mockSubscribeNewHeads = vi.fn().mockResolvedValue(mockUnsub);
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          subscribeNewHeads: mockSubscribeNewHeads,
+          getBlock: vi.fn(),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { unmount } = renderHook(() => useNewHeads(), { wrapper });
+
+    unmount();
+    // unsub should be called on cleanup
+    // Note: in this mock subscribeNewHeads returns without calling callback,
+    // so unsub may not be set. The important thing is it doesn't throw.
+    expect(mockSubscribeNewHeads).toHaveBeenCalled();
+  });
+});

--- a/services/explorer/src/test/hooks/useTx.test.ts
+++ b/services/explorer/src/test/hooks/useTx.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useTx } from '@/hooks/useTx';
+import { ApiContext } from '@/providers/ApiProvider';
+import type { ApiPromise } from '@polkadot/api';
+import type { ConnectionStatus } from '@/lib/types';
+
+const VALID_TX_HASH = '0x' + 'a'.repeat(64);
+const BLOCK_HASH_OBJ = {
+  toHex: () => '0x' + 'b'.repeat(64),
+};
+
+function makeWrapper(api: ApiPromise | null) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      ApiContext.Provider,
+      { value: { api, status: 'connected' as ConnectionStatus, blockNumber: null } },
+      children,
+    );
+  };
+}
+
+function makeMockExtrinsic(hash: string, signed = true) {
+  return {
+    hash: { toHex: () => hash },
+    method: {
+      section: 'balances',
+      method: 'transfer',
+      args: [{ toHuman: () => '5Dest...' }],
+      argsDef: { dest: 'AccountId' },
+    },
+    isSigned: signed,
+    signer: signed ? { toString: () => '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY' } : null,
+  };
+}
+
+describe('useTx', () => {
+  it('stays loading when api is null', () => {
+    const wrapper = makeWrapper(null);
+    const { result } = renderHook(() => useTx(VALID_TX_HASH), { wrapper });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error immediately for invalid tx hash', async () => {
+    const mockApi = {} as unknown as ApiPromise;
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useTx('not-a-hash'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/Invalid transaction hash/);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns error for hash with wrong length', async () => {
+    const mockApi = {} as unknown as ApiPromise;
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useTx('0x' + 'a'.repeat(63)), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toMatch(/Invalid transaction hash/);
+  });
+
+  it('finds tx in block and returns full data', async () => {
+    const mockEvents = [
+      {
+        phase: { applyExtrinsic: '0' },
+        event: {
+          section: 'system',
+          method: 'ExtrinsicSuccess',
+          data: {},
+        },
+      },
+      {
+        phase: { applyExtrinsic: '0' },
+        event: {
+          section: 'transactionPayment',
+          method: 'TransactionFeePaid',
+          data: { actualFee: '1000000000', tip: '0' },
+        },
+      },
+    ];
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockResolvedValue({ number: { toNumber: () => 5 } }),
+          getBlockHash: vi.fn().mockResolvedValue(BLOCK_HASH_OBJ),
+          getBlock: vi.fn().mockResolvedValue({
+            block: {
+              extrinsics: [makeMockExtrinsic(VALID_TX_HASH)],
+            },
+          }),
+        },
+      },
+      query: {
+        system: {
+          events: {
+            at: vi.fn().mockResolvedValue({ toHuman: () => mockEvents }),
+          },
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useTx(VALID_TX_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    const data = result.current.data;
+    expect(data).not.toBeNull();
+    expect(data?.hash).toBe(VALID_TX_HASH);
+    expect(data?.section).toBe('balances');
+    expect(data?.method).toBe('transfer');
+    expect(data?.success).toBe(true);
+    expect(data?.fee).toBe('1000000000');
+    expect(data?.tip).toBe('0');
+    expect(data?.events).toHaveLength(2);
+    expect(data?.blockNumber).toBe(5);
+    expect(data?.signer).toBeTruthy();
+  });
+
+  it('marks tx as failed when ExtrinsicFailed event present', async () => {
+    const failEvents = [
+      {
+        phase: { applyExtrinsic: '0' },
+        event: {
+          section: 'system',
+          method: 'ExtrinsicFailed',
+          data: {},
+        },
+      },
+    ];
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockResolvedValue({ number: { toNumber: () => 1 } }),
+          getBlockHash: vi.fn().mockResolvedValue(BLOCK_HASH_OBJ),
+          getBlock: vi.fn().mockResolvedValue({
+            block: {
+              extrinsics: [makeMockExtrinsic(VALID_TX_HASH, false)],
+            },
+          }),
+        },
+      },
+      query: {
+        system: {
+          events: {
+            at: vi.fn().mockResolvedValue({ toHuman: () => failEvents }),
+          },
+        },
+      },
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useTx(VALID_TX_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data?.success).toBe(false);
+    expect(result.current.data?.signer).toBeNull();
+  });
+
+  it('returns "not found" error when tx is in none of the blocks', async () => {
+    const DIFFERENT_HASH = '0x' + 'f'.repeat(64);
+
+    const mockApi = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockResolvedValue({ number: { toNumber: () => 3 } }),
+          getBlockHash: vi.fn().mockResolvedValue(BLOCK_HASH_OBJ),
+          getBlock: vi.fn().mockResolvedValue({
+            block: {
+              // This block contains a different tx
+              extrinsics: [makeMockExtrinsic(DIFFERENT_HASH)],
+            },
+          }),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    // Search for VALID_TX_HASH which is NOT in any block
+    const { result } = renderHook(() => useTx(VALID_TX_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    }, { timeout: 5000 });
+
+    expect(result.current.error).toMatch(/Transaction not found/);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('returns error when API throws during search', async () => {
+    const mockApi = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockRejectedValue(new Error('network error')),
+        },
+      },
+      query: {},
+    } as unknown as ApiPromise;
+
+    const wrapper = makeWrapper(mockApi);
+    const { result } = renderHook(() => useTx(VALID_TX_HASH), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('network error');
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/services/explorer/src/test/lib/api.test.ts
+++ b/services/explorer/src/test/lib/api.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Use vi.hoisted so variables are available inside the vi.mock factory (which is hoisted)
+const mockApiInstance = vi.hoisted(() => ({
+  isConnected: true,
+  disconnect: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@polkadot/api', () => ({
+  ApiPromise: {
+    create: vi.fn().mockResolvedValue(mockApiInstance),
+  },
+  WsProvider: vi.fn().mockImplementation(() => ({
+    disconnect: vi.fn(),
+  })),
+}));
+
+import { getApi, disconnectApi } from '@/lib/api';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+describe('lib/api', () => {
+  beforeEach(async () => {
+    // Reset singleton state before each test
+    await disconnectApi();
+    vi.clearAllMocks();
+    // Restore mock implementations cleared by clearAllMocks
+    (ApiPromise.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockApiInstance);
+    mockApiInstance.isConnected = true;
+    mockApiInstance.disconnect.mockResolvedValue(undefined);
+  });
+
+  describe('getApi', () => {
+    it('creates and returns an ApiPromise instance', async () => {
+      const api = await getApi();
+      expect(api).toBeDefined();
+      expect(ApiPromise.create).toHaveBeenCalledOnce();
+    });
+
+    it('creates a WsProvider with the WS URL', async () => {
+      await getApi();
+      expect(WsProvider).toHaveBeenCalled();
+    });
+
+    it('returns cached instance when already connected', async () => {
+      const api1 = await getApi();
+      const api2 = await getApi();
+      // Should return same object, create only called once
+      expect(api1).toBe(api2);
+      expect(ApiPromise.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconnects when existing api is not connected', async () => {
+      const api1 = await getApi();
+      // Simulate disconnection
+      mockApiInstance.isConnected = false;
+      const api2 = await getApi();
+      expect(api2).toBeDefined();
+      // ApiPromise.create called again for reconnection
+      expect(ApiPromise.create).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('disconnectApi', () => {
+    it('disconnects the api instance', async () => {
+      const api = await getApi();
+      await disconnectApi();
+      expect(api.disconnect).toHaveBeenCalledOnce();
+    });
+
+    it('handles disconnect when no instance exists', async () => {
+      // Singleton was cleared in beforeEach, no instance
+      await expect(disconnectApi()).resolves.toBeUndefined();
+    });
+
+    it('after disconnect, next getApi creates a fresh instance', async () => {
+      await getApi();
+      await disconnectApi();
+      vi.clearAllMocks();
+      (ApiPromise.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockApiInstance);
+      mockApiInstance.isConnected = true;
+
+      const newApi = await getApi();
+      expect(newApi).toBeDefined();
+      expect(ApiPromise.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/services/explorer/src/test/lib/format.test.ts
+++ b/services/explorer/src/test/lib/format.test.ts
@@ -124,12 +124,12 @@ describe('formatBalance', () => {
 
   it('formats a positive balance', () => {
     // 1 CLAW = 10^18 planck
-    const oneClaw = BigInt(10) ** BigInt(18);
+    const oneClaw = BigInt('1000000000000000000'); // 10^18
     expect(formatBalance(oneClaw)).toBe('1.0000 CLAW');
   });
 
   it('formats fractional balance', () => {
-    const halfClaw = BigInt(5) * BigInt(10) ** BigInt(17);
+    const halfClaw = BigInt('500000000000000000'); // 5 * 10^17
     expect(formatBalance(halfClaw)).toBe('0.5000 CLAW');
   });
 
@@ -146,7 +146,7 @@ describe('formatBalance', () => {
   });
 
   it('handles large balance', () => {
-    const large = BigInt(1000) * BigInt(10) ** BigInt(18);
+    const large = BigInt('1000000000000000000000'); // 1000 * 10^18
     expect(formatBalance(large)).toBe('1000.0000 CLAW');
   });
 });

--- a/services/explorer/tsconfig.json
+++ b/services/explorer/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Deploys the block explorer service. 136 tests, 97.58% coverage. Live at http://135.181.157.121:3000

## Changes
- Next.js block explorer with pages: /, /blocks, /blocks/[hash], /tx/[hash], /agents/[address]
- Connects to ClawChain RPC via WebSocket (ws://135.181.157.121:9944)
- Deployed on VPS via pm2 on port 3000

## Verification
- Build: ✅ 5 pages compiled successfully
- Tests: 136 tests, 97.58% coverage
- Live: http://135.181.157.121:3000 (title: ClawChain Explorer)