### PR TITLE
fix(ci): format cargo-audit ignore list as comma-separated values

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,8 +27,4 @@ jobs:
           # wasmtime 35.x is pulled by sc-executor-wasmtime (Substrate runtime).
           # Substrate has not yet upgraded beyond wasmtime 35 — tracked upstream.
           # Will be resolved when Substrate releases a version with wasmtime >=41.
-          ignore: |
-            RUSTSEC-2026-0020
-            RUSTSEC-2026-0006
-            RUSTSEC-2026-0021
-            RUSTSEC-2025-0118
+          ignore: RUSTSEC-2026-0020,RUSTSEC-2026-0006,RUSTSEC-2026-0021,RUSTSEC-2025-0118


### PR DESCRIPTION
## Problem

The Security Audit workflow is failing with a parse error:



The issue is that the `ignore` parameter uses YAML's literal scalar (`|`) which preserves newlines, but `cargo-audit` expects comma-separated values.

## Solution

Changed the ignore list from multi-line format to comma-separated values:

**Before:**
```yaml
ignore: |
  RUSTSEC-2026-0020
  RUSTSEC-2026-0006
  RUSTSEC-2026-0021
  RUSTSEC-2025-0118
```

**After:**
```yaml
ignore: RUSTSEC-2026-0020,RUSTSEC-2026-0006,RUSTSEC-2026-0021,RUSTSEC-2025-0118
```

This is the correct format expected by `rustsec/audit-check@v2`.

## Impact

- Fixes the failing Security Audit CI
- No functional changes to the security checks
- Same advisories are being ignored