### PR TITLE
fix(deps): patch yanked core2 v0.4.0 transitive dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,17 @@ futures = { version = "0.3" }
 
 [profile.release]
 panic = "unwind"
+
+# ============================================================
+# Yanked crate patches
+# ============================================================
+# core2 v0.4.0 was yanked from crates.io (2021-03-16) but is the only version
+# satisfying `^0.4.0` required by multihash v0.17.0, pulled in transitively:
+#   sc-network 0.55.1 → litep2p 0.13.0 → multihash 0.17.0 → core2 ^0.4.0
+# Without this patch, `cargo update` fails with:
+#   error: all dependencies containing yanked versions: core2 v0.4.0
+# We vendor the original 0.4.0 source (Apache-2.0, unchanged) under vendor/core2/.
+# Remove this patch once sc-network migrates to a litep2p version that uses
+# multihash 0.19+ (which drops core2 entirely).
+[patch.crates-io]
+core2 = { path = "vendor/core2" }


### PR DESCRIPTION
## Problem

`core2 v0.4.0` was yanked from crates.io but remains the only version satisfying the `^0.4.0` requirement from `multihash v0.17.0`, pulled in transitively:

```
sc-network 0.55.1 → litep2p 0.13.0 → multihash 0.17.0 → core2 ^0.4.0
```

This caused `cargo update` to fail:
```
error: all dependencies containing yanked versions: core2 v0.4.0
```

## Fix

Vendor the original `core2 0.4.0` source (Apache-2.0, unchanged from crates.io release) under `vendor/core2/` and add a `[patch.crates-io]` entry to the workspace `Cargo.toml`. Cargo resolves the yanked registry entry to our local copy.

## Removal Path

Once polkadot-sdk migrates `sc-network` to a `litep2p` version that uses `multihash 0.19+` (which drops the `core2` dep entirely), delete `vendor/core2/` and the `[patch.crates-io]` block.

## Verification

- `cargo update` — ✅ EXIT 0, no yanked-version errors
- `cargo check --workspace` — ✅ EXIT 0, all 18 crates pass